### PR TITLE
hotfix: Fixing critical bug with bearer token user injection use case.

### DIFF
--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -109,11 +109,7 @@ end
 
 function introspect(oidcConfig)
   if utils.has_bearer_access_token() or oidcConfig.bearer_only == "yes" then
-    local res, err, original_url, session = require("resty.openidc").introspect(oidcConfig)
-
-    -- @todo: add unit test to check for session:close()
-    -- handle and close session, prevent locking
-    session:close()
+    local res, err = require("resty.openidc").introspect(oidcConfig)
 
     if err then
       if oidcConfig.bearer_only == "yes" then


### PR DESCRIPTION
`introspect` method returns **2** things only **NOT** 4. It returns json and err.

See:
https://github.com/zmartzone/lua-resty-openidc/blob/master/lib/resty/openidc.lua#L1580
https://github.com/zmartzone/lua-resty-openidc/blob/master/lib/resty/openidc.lua#L1594
https://github.com/zmartzone/lua-resty-openidc/blob/master/lib/resty/openidc.lua#L1621
https://github.com/zmartzone/lua-resty-openidc/blob/master/lib/resty/openidc.lua#L1659